### PR TITLE
support for CentOS 5.x, plus version name and buildreq fix

### DIFF
--- a/spec/haproxy.spec
+++ b/spec/haproxy.spec
@@ -13,7 +13,7 @@
 Name: haproxy
 Summary: HA-Proxy is a TCP/HTTP reverse proxy for high availability environments
 Version: %{version}
-Release: %{version}
+Release: %{release}
 License: GPLv2+
 URL: http://www.haproxy.org/
 Group: System Environment/Daemons
@@ -32,8 +32,8 @@ Requires(postun): /sbin/service
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: pcre-devel openssl-devel
+BuildRequires: setup >= 2.5
 Requires: pcre openssl
-Requires: setup >= 2.8.14-14
 
 %description
 HAProxy is a free, fast and reliable solution offering high


### PR DESCRIPTION
Build was creating haproxy-1.5.0-1.5.0.x86_64.rpm instead of haproxy-1.5.0-1.x86_64.rpm.  Pegging to setup 2.8 was not needed, repegged to 2.5.  Setup is a buildreq, not req.
