### PR TITLE
Updated to latest stable release

### DIFF
--- a/spec/haproxy.spec
+++ b/spec/haproxy.spec
@@ -6,7 +6,7 @@
 %define haproxy_confdir %{_sysconfdir}/haproxy
 %define haproxy_datadir %{_datadir}/haproxy
 
-%define version 1.5.0
+%define version 1.5.1
 #%define dev_rel dev25
 #%define release 1
 


### PR DESCRIPTION
HAProxy 1.5.1 version was released yesterday to fix some serious stability issues:

Version 1.5.1 fixes a few bugs from 1.5.0 among which a really annoying one which can cause some file descriptor leak when dealing with clients which disappear from the net, resulting in the impossibility to accept new connections after some time. This bug was introduced in 1.5-dev25, so affected users are strongly encouraged to upgrade. For more information, please consult the source code and changelog here.

http://www.haproxy.org/download/1.5/src/CHANGELOG
