### PR TITLE
Build with zlib for HTTP compression support

### DIFF
--- a/spec/haproxy.spec
+++ b/spec/haproxy.spec
@@ -31,9 +31,9 @@ Requires(preun): /sbin/service
 Requires(postun): /sbin/service
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires: pcre-devel openssl-devel
+BuildRequires: pcre-devel openssl-devel zlib-devel
 BuildRequires: setup >= 2.5
-Requires: pcre openssl
+Requires: pcre openssl zlib
 
 %description
 HAProxy is a free, fast and reliable solution offering high
@@ -53,7 +53,7 @@ possibility not to expose fragile web servers to the net.
 use_regparm="USE_REGPARM=1"
 %endif
 
-make %{?_smp_mflags} CPU="generic" TARGET="linux26" USE_PCRE=1 USE_OPENSSL=1 ${use_regparm}
+make %{?_smp_mflags} CPU="generic" TARGET="linux26" USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1 ${use_regparm}
 
 pushd contrib/halog
 make halog


### PR DESCRIPTION
Enabling the gzip compression algorithm in HAProxy requires it to be built with zlib support.
