### PR TITLE
Update HAProxy and add Vagrantfile based builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant/
+*.rpm

--- a/README.markdown
+++ b/README.markdown
@@ -1,31 +1,41 @@
 # A Recipe for a haproxy 1.5 stable version RPM on CentOS
 
+## Easy install:
+
+Clone this repository, install vagrant and run:
+
+    vagrant up
+
+The RPMs will be created and placed in this directory.
+
+## Manual Install
+
 Perform the following on a build box as a regular user.
 
-## Create an RPM Build Environment
+### Create an RPM Build Environment
 
-Install rpmdevtools from the [EPEL][epel] repository:
+Install rpmdevtools:
 
     sudo yum install rpmdevtools pcre-devel
     rpmdev-setuptree
 
-## Install Prerequisites for RPM Creation
+### Install Prerequisites for RPM Creation
 
     sudo yum groupinstall 'Development Tools'
     sudo yum install openssl-devel
 
-## Download haproxy
+### Download haproxy
 
     wget http://www.haproxy.org/download/1.5/src/haproxy-1.5.3.tar.gz
     mv haproxy-1.5.3.tar.gz ~/rpmbuild/SOURCES/
 
-## Get Necessary System-specific Configs
+### Get Necessary System-specific Configs
 
     git clone git://github.com/bluerail/haproxy-centos.git
     cp haproxy-centos/conf/* ~/rpmbuild/SOURCES/
     cp haproxy-centos/spec/* ~/rpmbuild/SPECS/
 
-## Build the RPM
+### Build the RPM
 
     cd ~/rpmbuild/
     rpmbuild -ba SPECS/haproxy.spec
@@ -38,4 +48,3 @@ Based on the Red Hat 6.4 RPM spec for haproxy 1.4.
 
 Maintained by [Martijn Storck](martijn@bluerail.nl)
 
-[EPEL]: http://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,53 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This Vagrantfile will build an RPM of the current version of the RPM spec
+# Just run vagrant up, and wait for the rpm and srpm to be written to the cwd.
+
+$buildrpm = <<BUILDRPM
+echo "Running the HAProxy build script"
+
+VERSION=`grep "^%define version" /vagrant/spec/haproxy.spec | cut -d ' ' -f 3`
+echo Building HAProxy ${VERSION}
+
+echo "Installing yum dependencies"
+sudo yum install -y rpmdevtools pcre-devel openssl-devel
+sudo yum groupinstall -y 'Development Tools'
+echo "Yum depenencies installed."
+
+echo "Setting up RPM build env"
+rpmdev-setuptree
+
+echo "Downloading HAProxy"
+curl -o ~/rpmbuild/SOURCES/haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/1.5/src/haproxy-${VERSION}.tar.gz
+
+echo "Copying configs from git."
+cp /vagrant/conf/* ~/rpmbuild/SOURCES/
+cp /vagrant/spec/* ~/rpmbuild/SPECS/
+
+echo "Building..."
+cd ~/rpmbuild/
+rpmbuild -ba SPECS/haproxy.spec
+
+echo "Copying output to the vagrant share."
+cp ~/rpmbuild/RPMS/x86_64/* /vagrant
+cp ~/rpmbuild/SRPMS/* /vagrant
+
+echo "Done building HAProxy " ${VERSION}
+BUILDRPM
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Bare bones CentOS 6.5 box from a trustworthy community member.
+  config.vm.box = "centos-65-x64-virtualbox-nocm.box"
+  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box"
+
+  # This optional plugin caches RPMs for faster rebuilds.
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :machine
+  end
+
+  config.vm.provision "shell", privileged: false, inline: $buildrpm
+end

--- a/spec/haproxy.spec
+++ b/spec/haproxy.spec
@@ -6,7 +6,7 @@
 %define haproxy_confdir %{_sysconfdir}/haproxy
 %define haproxy_datadir %{_datadir}/haproxy
 
-%define version 1.5.3
+%define version 1.5.4
 #%define dev_rel dev25
 #%define release 1
 
@@ -121,6 +121,9 @@ fi
 %exclude %{_sbindir}/haproxy-systemd-wrapper
 
 %changelog
+* Thu Sep 18 2014 Daniel Pfile <daniel@pfile.net> - 1.5.4
+- Update to haproxy 1.5.4
+
 * Wed Aug 20 2014 Alan Ivey <alanivey@gmail.com> - 1.5.3
 - Update to haproxy 1.5.3
 - Add %{dist} to Release


### PR DESCRIPTION
The Vagrantfile uses the no config management software version of Puppetlab's CentOS 6.5 base box, then runs the steps to build the RPM. EPEL is no longer needed on EL6 to build this RPM.
